### PR TITLE
Update for rusoto 0.34 and rustls support

### DIFF
--- a/serde_dynamodb/Cargo.toml
+++ b/serde_dynamodb/Cargo.toml
@@ -15,9 +15,13 @@ travis-ci = { repository = "mockersf/serde_dynamodb" }
 
 [dependencies]
 serde = "1.0"
-rusoto_dynamodb = "0.33"
+rusoto_dynamodb = { version = "0.34", default-features = false }
 
 [dev-dependencies]
 serde_derive = "1.0"
-rusoto_core = "0.33"
-rusoto_dynamodb = "0.33"
+rusoto_core = "0.34"
+rusoto_dynamodb = "0.34"
+
+[features]
+default = ["rusoto_dynamodb/default"]
+rustls = ["rusoto_dynamodb/rustls"]


### PR DESCRIPTION
This is a version of the 0.34 update that includes support for rustls.