### PR TITLE
Quick implementation of unit and unit struct

### DIFF
--- a/serde_dynamodb/src/de.rs
+++ b/serde_dynamodb/src/de.rs
@@ -214,18 +214,27 @@ impl<'de, 'a, R: Read> serde::de::Deserializer<'de> for &'a mut Deserializer<R> 
         }
     }
 
-    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
     where
         V: serde::de::Visitor<'de>,
     {
-        unimplemented!()
+        self.read
+            .get_attribute_value(&self.current_field)
+            .ok_or_else(|| Error {
+                message: "Missing field".to_owned(),
+            })?
+            .null
+            .ok_or_else(|| Error {
+                message: format!("Missing null for field {:?}", &self.current_field),
+            })
+            .and_then(|_| visitor.visit_unit())
     }
 
-    fn deserialize_unit_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value>
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
     where
         V: serde::de::Visitor<'de>,
     {
-        unimplemented!()
+        self.deserialize_unit(visitor)
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &str, visitor: V) -> Result<V::Value>

--- a/serde_dynamodb/src/ser.rs
+++ b/serde_dynamodb/src/ser.rs
@@ -139,11 +139,17 @@ where
     }
 
     fn serialize_unit(self) -> Result<()> {
-        self.reject_non_struct_root(&mut move |_writer: &mut W| Ok(()))
+        self.reject_non_struct_root(&mut move |writer: &mut W| {
+            writer.insert_value(AttributeValue {
+                null: Some(true),
+                ..Default::default()
+            });
+            Ok(())
+        })
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<()> {
-        unimplemented!()
+        self.serialize_unit()
     }
 
     fn serialize_unit_variant(

--- a/serde_dynamodb/tests/test.rs
+++ b/serde_dynamodb/tests/test.rs
@@ -101,6 +101,8 @@ fn can_go_back_and_forth() {
         f: f64,
     }
     #[derive(Deserialize, Serialize, Debug, PartialEq)]
+    struct Unit;
+    #[derive(Deserialize, Serialize, Debug, PartialEq)]
     struct Basic {
         i: i32,
         j: i32,
@@ -114,6 +116,8 @@ fn can_go_back_and_forth() {
         some: Option<Internal>,
         none: Option<Internal>,
         complex: Vec<Option<Internal>>,
+        unit: (),
+        unit_struct: Unit,
     }
     let value = Basic {
         i: 18,
@@ -128,6 +132,8 @@ fn can_go_back_and_forth() {
         some: Some(Internal { k: 120, f: 144.304 }),
         none: None,
         complex: vec![None, Some(Internal { k: 10, f: 12.56 })],
+        unit: (),
+        unit_struct: Unit,
     };
     let hm = serde_dynamodb::to_hashmap(&value).unwrap();
     let out: Basic = serde_dynamodb::from_hashmap(hm).unwrap();

--- a/serde_dynamodb_derive/src/lib.rs
+++ b/serde_dynamodb_derive/src/lib.rs
@@ -202,7 +202,7 @@ fn get_string_from_lit(attr_name: &str, lit: &syn::Lit) -> String {
 
 fn get_meta_items_from(domain: &str, attr: &syn::Attribute) -> Option<Vec<syn::NestedMetaItem>> {
     match attr.value {
-        List(ref name, ref items) if name == domain => Some(items.iter().cloned().collect()),
+        List(ref name, ref items) if name == domain => Some(items.to_vec()),
         _ => None,
     }
 }


### PR DESCRIPTION
Hi! I've just started with Rust, and am doing some work with DynamoDB. Came across serde_dynamodb and found it to be a great solution to the DynamoDB need for AttributeMap mapping, but found that some of my types hit the `unimplemented!` code. I'm just starting to try and fill in a few of those gaps.

I've started with unit and unit struct as they seem pretty simple - I've made the "choice" that they're both best serialised as a null value - hopefully that makes sense!

If you're happy with some pull requests I'll try and fill in some more gaps - although I might be quite slow as I'm learning while doing!